### PR TITLE
Fix issue introduced in Rollout 2.2.1

### DIFF
--- a/lib/rollout_ui/feature.rb
+++ b/lib/rollout_ui/feature.rb
@@ -18,7 +18,7 @@ module RolloutUi
     end
 
     def user_ids
-      rollout.get(feature_for(name)).users
+      rollout.get(feature_for(name)).users.to_a
     end
 
     def percentage=(percentage_val)


### PR DESCRIPTION
- Rollout started using Set instead of Array for users and groups
  here: https://github.com/fetlife/rollout/commit/a6e0b4b240006e3d9ee0cb1147e1235fec723ab0.
  Set doesn't not provide a join method, so we must call to_a first.